### PR TITLE
Adding basic game states feature

### DIFF
--- a/code/Game.cs
+++ b/code/Game.cs
@@ -1,4 +1,5 @@
 using Sandbox;
+using TerryForm.States;
 using TerryForm.UI;
 
 namespace TerryForm
@@ -6,10 +7,13 @@ namespace TerryForm
 	public partial class Game : Sandbox.Game
 	{
 		public static Game Instance => Current as Game;
+		public static StateHandler StateHandler { get; private set; }
 
 		public Game()
 		{
 			_ = new HudEntity();
+			StateHandler = new();
+			Event.Register( StateHandler );
 		}
 
 		public override void ClientJoined( Client cl )
@@ -18,6 +22,8 @@ namespace TerryForm
 
 			var pawn = new Player();
 			cl.Pawn = pawn;
+
+			StateHandler.State.OnPlayerJoin( pawn );
 
 			pawn.Respawn();
 		}

--- a/code/States/BaseState.cs
+++ b/code/States/BaseState.cs
@@ -1,0 +1,74 @@
+﻿using Sandbox;
+using System.Collections.Generic;
+
+namespace TerryForm.States
+{
+	public abstract partial class BaseState : BaseNetworkable
+	{
+		public virtual string StateName => "";
+		public virtual int StateDuration => 0;
+		public float StateEndTime { get; set; }
+
+		public List<Player> PlayerList = new();
+
+		public float TimeLeft
+		{
+			get
+			{
+				return StateEndTime - Time.Now;
+			}
+		}
+
+		public void Start()
+		{
+			if ( Host.IsServer && StateDuration > 0 )
+			{
+				StateEndTime = Time.Now + StateDuration;
+			}
+
+			OnStart();
+		}
+
+		public void Finish()
+		{
+			if ( Host.IsServer )
+			{
+				StateEndTime = 0f;
+				PlayerList.Clear();
+			}
+
+			OnFinish();
+		}
+
+		public void AddPlayer( Player player )
+		{
+			Host.AssertServer();
+
+			if ( !PlayerList.Contains( player ) ) PlayerList.Add( player );
+		}
+
+		public virtual void OnPlayerSpawn( Player player ) { }
+
+		public virtual void OnPlayerJoin( Player player ) { }
+
+		public virtual void OnPlayerLeave( Player player ) { }
+
+		public virtual void OnTick()
+		{
+			if ( Host.IsServer )
+			{
+				if ( StateEndTime > 0f && Time.Now >= StateEndTime )
+				{
+					StateEndTime = 0f;
+					OnTimeUp();
+				}
+			}
+		}
+
+		protected virtual void OnStart() { }
+
+		protected virtual void OnFinish() { }
+
+		protected virtual void OnTimeUp() { }
+	}
+}

--- a/code/States/StateHandler.cs
+++ b/code/States/StateHandler.cs
@@ -1,0 +1,29 @@
+﻿using Sandbox;
+
+namespace TerryForm.States
+{
+	public partial class StateHandler : BaseNetworkable
+	{
+		[Net] public BaseState State { get; set; } = new WaitingState();
+
+		public StateHandler()
+		{
+			State.Start();
+		}
+
+		public void ChangeState( BaseState state )
+		{
+			Assert.NotNull( state );
+
+			State?.Finish();
+			State = state;
+			State?.Start();
+		}
+
+		[Event.Tick]
+		private void Tick()
+		{
+			State?.OnTick();
+		}
+	}
+}

--- a/code/States/WaitingState.cs
+++ b/code/States/WaitingState.cs
@@ -1,0 +1,28 @@
+﻿
+
+namespace TerryForm.States
+{
+	public partial class WaitingState : BaseState
+	{
+		public override string StateName => "WAITING";
+
+		protected override void OnStart()
+		{
+			Log.Info( $"Starting {StateName} State" );
+			base.OnStart();
+		}
+
+		protected override void OnFinish()
+		{
+			Log.Info( $"Ending {StateName} State" );
+			base.OnFinish();
+		}
+
+		public override void OnPlayerJoin( Player player )
+		{
+			AddPlayer( player );
+
+			base.OnPlayerJoin( player );
+		}
+	}
+}


### PR DESCRIPTION
Closes #4 

Adding Game States. This was implemented similar to sbox-hover as mentioned in the corresponding issue. The StateHandler is used to abstract State logic from the Game class, which tends to get bloated by functions not directly pertaining to it. Any stateful logic functions should be written in StateHandler, while Game doesn't use knowledge of State at all.