### PR TITLE
Basic inventory without any hooks into input or worm

### DIFF
--- a/code/Pawn/Inventory.cs
+++ b/code/Pawn/Inventory.cs
@@ -1,0 +1,37 @@
+﻿using Sandbox;
+using System;
+using System.Linq;
+using TerryForm.Weapons;
+
+namespace TerryForm.Pawn
+{
+	public class Inventory : BaseInventory
+	{
+		public Inventory( Player player ) : base( player )
+		{
+
+		}
+
+		public override bool Add( Entity ent, bool makeActive = false )
+		{
+			var player = Owner as Player;
+			var weapon = ent as Weapon;
+
+			// If this weapon is a pick-up, add ammo to player's existing weapon of the same type.
+			if ( weapon != null && IsCarryingType( ent.GetType() ) )
+			{
+				var existingWeapon = (Weapon)List.Where( x => x.GetType() == weapon.GetType() ).FirstOrDefault();
+				if ( existingWeapon.Ammo != -1 ) existingWeapon.Ammo++;
+
+				ent.Delete();
+			}
+
+			return base.Add( ent, makeActive );
+		}
+
+		public bool IsCarryingType( Type t )
+		{
+			return List.Any( x => x.GetType() == t );
+		}
+	}
+}

--- a/code/Pawn/Player.cs
+++ b/code/Pawn/Player.cs
@@ -18,10 +18,13 @@ namespace TerryForm.Pawn
 		{
 			IsAlive = true;
 
+			// Initialize the Inventory with all weapons.
 			Inventory = new Inventory( this );
-			foreach ( var weapon in Library.GetAll<Weapon>().Where( weapon => !weapon.IsAbstract ) )
+			var weapons = Library.GetAll<Weapon>()
+				.Where( weapon => !weapon.IsAbstract );
+			foreach ( var weapon in weapons )
 			{
-
+				Inventory.Add( Library.Create<Weapon>( weapon ) );
 			}
 
 			for ( int i = 0; i < GameConfig.WormCount; i++ )

--- a/code/Pawn/Player.cs
+++ b/code/Pawn/Player.cs
@@ -1,6 +1,7 @@
 ﻿using Sandbox;
 using System.Collections.Generic;
 using TerryForm.Utils;
+using TerryForm.Weapons;
 using System.Linq;
 
 namespace TerryForm.Pawn
@@ -16,6 +17,12 @@ namespace TerryForm.Pawn
 		public Player( Client cl ) : this()
 		{
 			IsAlive = true;
+
+			Inventory = new Inventory( this );
+			foreach ( var weapon in Library.GetAll<Weapon>().Where( weapon => !weapon.IsAbstract ) )
+			{
+
+			}
 
 			for ( int i = 0; i < GameConfig.WormCount; i++ )
 			{

--- a/code/Utils/GameConfig.cs
+++ b/code/Utils/GameConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace TerryForm.Utils
+﻿using System.Collections.Generic;
+
+namespace TerryForm.Utils
 {
 	public static class GameConfig
 	{
@@ -6,5 +8,13 @@
 		public static int TurnDurationSeconds { get; set; } = 45;
 		public static int TurnTimeRemainingAfterFired { get; set; } = 5;
 		public static int MinimumPlayersToStart { get; set; } = 2;
+		public static Dictionary<string, int> LoadoutDefaults = new()
+		{
+			{ "BaseballBat", 2 },
+			{ "Bazooka", -1 },
+			{ "Grenade", -1 },
+			{ "Railgun", 0 },
+			{ "Shotgun", 2 },
+		};
 	}
 }

--- a/code/Weapons/Weapon.cs
+++ b/code/Weapons/Weapon.cs
@@ -21,6 +21,7 @@ namespace TerryForm.Weapons
 			base.Spawn();
 
 			SetModel( ModelPath );
+			Ammo = GameConfig.LoadoutDefaults[ClassInfo.Name];
 		}
 
 		public void SetWeaponEnabled( bool shouldEnable )
@@ -60,6 +61,8 @@ namespace TerryForm.Weapons
 		{
 			if ( !IsFiredTurnEnding )
 				return;
+
+			Ammo--;
 
 			/* 
 			 * TODO: Let physics resolve and weapon to finish firing before ending the players turn.

--- a/code/Weapons/Weapon.cs
+++ b/code/Weapons/Weapon.cs
@@ -14,6 +14,7 @@ namespace TerryForm.Weapons
 		public virtual bool IsFiredTurnEnding => false;
 		[Net] public bool WeaponEnabled { get; set; }
 		private WormAnimator Animator { get; set; }
+		public virtual int Ammo { get; set; } = 0;
 
 		public override void Spawn()
 		{


### PR DESCRIPTION
This is probably the extent of what I can write for Inventory without some kind of Input and Simulate 101. If you think it's good and can build off of it, merge it!

How it works:
- Player has an Inventory (inventory is shared across all of a Player's Worms)
- Inventory is initialized in Player constructor, and all items that are a subclass of Weapon are added to the Inventory.
- After initialization, using Inventory.Add( weapon ) will simply add ammo to the existing Weapon in the Inventory List, so we can use that for crate drops in the future.